### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "obia"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Python package for object-based image analysis with multimodal data sources"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bump OBIA package version from 0.1.3 to 0.1.4 so the next release tag can publish to PyPI without conflicting with the existing 0.1.3 package.

## Validation

- python -m pytest -q
- mkdocs build --strict
- python -m build
- git diff --check

## Notes

Docs are configured for https://obia.sefa.ai via mkdocs.yml, docs/CNAME, and the GitHub Pages deploy workflow.